### PR TITLE
Added pkg-config file xmlrpc_cpp.pc for legacy c++ wrapper

### DIFF
--- a/src/cpp/meson.build
+++ b/src/cpp/meson.build
@@ -15,6 +15,14 @@ libxmlrpc_cpp = library(
   version : '8.@0@'.format(version_minor),
   install : true,
 )
+pkgg.generate(
+  name : 'xmlrpc_cpp',
+  description : 'Legacy Xmlrpc-c C++ wrapper',
+  version : meson.project_version(),
+  requires : ['xmlrpc', 'xmlrpc_server', 'xmlrpc_util'],
+  libraries : libxmlrpc_cpp,
+  install : true,
+)
 
 libxmlrpcpp = library(
   'xmlrpc++',


### PR DESCRIPTION
This file is not part of the original xmlrpc-c package but has (at least) been a part of the xmlrpc-c-devel package for Centos up to version 1.32.5-1905. 
When this file is missing it breaks the `xmlrpc-c-config c++`  command as it relies on the xmlrpc_cpp.pc file.

From what I can find it was added by the CMake build system that the packages previously were based on.
See: https://github.com/ensc/xmlrpc-c/blob/master/src/cpp/xmlrpc_cpp.pc.cmake

I had to change "Requires.private" to only "Requires" or I got an `undefined reference to symbol 'xmlrpc_INCREF'` when trying to link against the library. As I am not so familiar with either Meson, CMake or Makefiles I do not have the skills to understand why, but removing the .private part solved my issue. 